### PR TITLE
Updating to new OAuth 2.0 endpoints

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -18,7 +18,7 @@ module.exports = LinkedIn;
  * Base endpoint
  */
 
-var endpoint = 'https://www.linkedin.com/uas/oauth2/authorization';
+var endpoint = 'https://www.linkedin.com/oauth/v2/authorization';
 
 /**
  * Default options

--- a/lib/server.js
+++ b/lib/server.js
@@ -16,7 +16,7 @@ module.exports = LinkedIn;
  * Access Token Endpoint
  */
 
-var access_token_endpoint = 'https://www.linkedin.com/uas/oauth2/accessToken';
+var access_token_endpoint = 'https://www.linkedin.com/oauth/v2/accessToken';
 
 /**
  * API Endpoint


### PR DESCRIPTION
LinkedIn has changed their OAuth 2.0 URLs. This is a breaking change and it is described here: https://developer.linkedin.com/blog/posts/2018/redirecting-oauth-uas

This PR updates to the new URLs.